### PR TITLE
(GH-5) Adds GitHub default funding file

### DIFF
--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,21 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+
+patreon: # Replace with a single Patreon username
+
+open_collective: # Replace with a single Open Collective username
+
+ko_fi: # Replace with a single Ko-fi username
+
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+
+liberapay: # Replace with a single Liberapay username
+
+issuehunt: # Replace with a single IssueHunt username
+
+otechie: # Replace with a single Otechie username
+
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you like this project please star it and share it with others.
 - A Pull request template
 - A README file with all you need
 - Automated Semantic Versioning thanks to [GitVersion](https://github.com/GitTools/GitVersion)
+- A [funding file](./FUNDING.md) to easily enable sponsorships in your repository
+
 
 # Installation
 Click on "Use Template" to create a repository based on this one.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change adds a funding file to the repo. 
This way people can donate to developers or the project directly and support it that way.
Currently there are no sponsorships or donation possibilities setup which might change in the future.
For now only the default GitHub funding file has been added to show off the possibilities.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- Please use closing keywords like 'Fixes' or 'Resolves' or similar -->
Resolves #5 
